### PR TITLE
hal: tdk: fix error in imu drivers

### DIFF
--- a/icm42x7x/imu/inv_imu_driver.c
+++ b/icm42x7x/imu/inv_imu_driver.c
@@ -797,7 +797,8 @@ int inv_imu_get_data_from_registers(inv_imu_device_t *s)
 	inv_imu_sensor_event_t event;
 
 	/* Ensure data ready status bit is set */
-	if (status |= inv_imu_read_reg(s, INT_STATUS_DRDY, 1, &int_status))
+	status |= inv_imu_read_reg(s, INT_STATUS_DRDY, 1, &int_status);
+	if (status)
 		return status;
 
 	if (int_status & INT_STATUS_DRDY_DATA_RDY_INT_MASK) {


### PR DESCRIPTION
Fix error: using the result of an assignment as a condition without parentheses [-Werror,-Wparentheses] (#2)
Reported by Zephyr automatic build

Signed-off-by: Aurelie Fontaine [aurelie.fontaine@tdk.com]