### PR TITLE
HAL: TDK: Added root directory include set for avoid build conflict

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,7 @@
 if(CONFIG_TDK_HAL)
 
   zephyr_library()
+  zephyr_include_directories(.)
 
   if(CONFIG_USE_EMD_ICM42670 OR CONFIG_USE_EMD_ICM42370)
 


### PR DESCRIPTION
Subject: Added root directory include set for avoid build conflict

Added root directory include set for avoid build conflict while load same header file name

Signed-off-by: JuHyun Kim [jh.kim@tdk.com](mailto:jh.kim@tdk.com)