### PR TITLE
Features/apply add chip name to header files (#22)

### DIFF
--- a/icm456xx/imu/inv_imu_driver.h
+++ b/icm456xx/imu/inv_imu_driver.h
@@ -18,7 +18,7 @@
 extern "C" {
 #endif
 
-#include "icm456xx/imu/inv_imu.h"
+#include "icm456xx/icm456xx_h/imu/inv_imu.h"
 #include "icm456xx/imu/inv_imu_defs.h"
 #include "icm456xx/imu/inv_imu_transport.h"
 


### PR DESCRIPTION
* Added chip header path to #include, applied format script

* Fixed incorrect file path in inv_imu_driver.h of icm456xx